### PR TITLE
Config: truffle test on jenkins | solidity-coverage fix

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,9 +1,5 @@
-const { GAS_LIMIT } = require('./config/params.js');
 
 module.exports = {
-  port: 8555,
-  testrpcOptions: `-p 8555 -l ${GAS_LIMIT}`,
   norpc: false,
-  testCommand: 'truffle test',
   skipFiles: ['zeppelin/BasicToken.sol', 'zeppelin/Destructible.sol', 'zeppelin/ERC20.sol', 'zeppelin/ERC20Basic.sol', 'zeppelin/Ownable.sol', 'zeppelin/SafeMath.sol', 'zeppelin/StandardToken.sol', 'TestToken.sol']
 };

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ Allows for users to create buy and sell orders for baskets, fill orders, and tra
 - [Truffle](http://truffleframework.com/) [v4.1.8](https://github.com/trufflesuite/truffle/releases/tag/v4.1.8)
 
 ```
-truffle test
+npm test
 ```
 
 **Running test coverage (solidity-coverage)**
 
 ```sh
-./node_modules/.bin/solidity-coverage
+# Requires environment variable TEST_COVERAGE=true, which is set in the npm script:
+npm run coverage
 ```
 
 ## Deployed Contracts: Ropsten Testnet

--- a/config.js
+++ b/config.js
@@ -16,4 +16,13 @@ module.exports = {
   DECIMALS: 18,
   INITIAL_SUPPLY: 100e18,
   FAUCET_AMOUNT: 1e18,
+
+  // RPC Port
+  // NOTE:    truffle test creates a new testrpc on port 7545, while the default port for
+  //          solidity-coverage is 8555.
+  //          Excluding 'test'/'development' and 'coverage' networks from specifications in
+  //          truffle.js results in truffle creating its own default testrpc instances.
+  // WARNING: Using ports other than the default ports may result in `truffle test` or
+  //          `solidity-coverage` failure.
+  PORT: process.env.TEST_COVERAGE ? 8555 : 7545,
 };

--- a/migrations/constructors.js
+++ b/migrations/constructors.js
@@ -11,15 +11,20 @@ const allArtifacts = {
   Basket: artifacts.require('./Basket.sol'),
 };
 
+// solidity-coverage: fails if gasPrice is specified
+// https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#running-out-of-gas
+// Remove gasPrice when running test coverage:
+const gasObj = process.env.TEST_COVERAGE ? {} : { gasPrice: GAS_PRICE_DEV };
+
 const constructors = {
-  BasketRegistry: _owner => allArtifacts.BasketRegistry.new({ from: _owner, gasPrice: GAS_PRICE_DEV }),
+  BasketRegistry: _owner => allArtifacts.BasketRegistry.new(Object.assign({}, { from: _owner }, gasObj)),
 
   BasketEscrow: (_owner, _basketRegistryAddress, _transactionFeeRecipient, _transactionFee) =>
     allArtifacts.BasketEscrow.new(
       _basketRegistryAddress,
       _transactionFeeRecipient,
       _transactionFee,
-      { from: _owner, gasPrice: GAS_PRICE_DEV },
+      Object.assign({}, { from: _owner }, gasObj),
     ),
 
   BasketFactory: (_owner, _basketRegistryAddress, _productionFeeRecipient, _productionFee) =>
@@ -27,7 +32,7 @@ const constructors = {
       _basketRegistryAddress,
       _productionFeeRecipient,
       _productionFee,
-      { from: _owner, gasPrice: GAS_PRICE_DEV },
+      Object.assign({}, { from: _owner }, gasObj),
     ),
 
   TestToken: (_owner, _name, _symbol, _decimals, _initialSupply, _faucetAmount) =>
@@ -37,7 +42,7 @@ const constructors = {
       _decimals,
       _initialSupply,
       _faucetAmount,
-      { from: _owner, gasPrice: GAS_PRICE_DEV },
+      Object.assign({}, { from: _owner }, gasObj),
     ),
 
   Basket: (_owner, _name, _symbol, _tokens, _weights, _registryAddress, _arranger, _arrangerFeeRecipient, _arrangerFee) =>
@@ -50,10 +55,9 @@ const constructors = {
       _arranger,
       _arrangerFeeRecipient,
       _arrangerFee,
-      { from: _owner, gasPrice: GAS_PRICE_DEV },
+      Object.assign({}, { from: _owner }, gasObj),
     ),
 };
-
 
 module.exports = {
   constructors,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "truffle.js",
   "scripts": {
     "test": "rm -rf build && truffle compile && truffle test",
-    "coverage": "touch allFiredEvents && ./node_modules/.bin/solidity-coverage"
+    "coverage": "TEST_COVERAGE=true npm run run:coverage",
+    "run:coverage": "rm -rf build && ./node_modules/.bin/solidity-coverage"
   },
   "repository": {
     "type": "git",

--- a/truffle.js
+++ b/truffle.js
@@ -1,5 +1,3 @@
-const { GAS_PRICE_DEV, GAS_LIMIT_DEV } = './config';
-
 module.exports = {
   networks: {
     ropsten: {
@@ -25,13 +23,6 @@ module.exports = {
       gas: 8e6,
       gasPrice: 20e9,           // 20 GWei
       network_id: '1',
-    },
-    coverage: {
-      host: 'localhost',
-      port: 8555,
-      gas: GAS_LIMIT_DEV,
-      gasPrice: GAS_PRICE_DEV,  // 20 GWei
-      network_id: '*',
     },
   },
 };

--- a/utils/web3.js
+++ b/utils/web3.js
@@ -1,7 +1,8 @@
 const Promise = require('bluebird');
-const ganache = require('ganache-cli');
 const Web3 = require('web3');
+const { PORT } = require('../config');
 
+const web3 = new Web3(new Web3.providers.HttpProvider(`http://localhost:${PORT}`));
 if (!web3.eth.getAccountsPromise) Promise.promisifyAll(web3.eth, { suffix: 'Promise' });
 
 module.exports = { web3 };


### PR DESCRIPTION
**solidity-coverage**
- failures if specifying gas/gasLimits: [docs](https://github.com/sc-forks/solidity-coverage/blob/master/docs/faq.md#running-out-of-gas)
- port: 8555 required; even if overridden in configs, truffle test may still search for a connection on port 8555, resulting in failure
- ensure solidity-coverage is run on port 8555

**truffle-test**
- the built-in web3 may lose connection if not on the default port of 7555
- ensure testrpc for truffle test is on 7545